### PR TITLE
Addition of a Raw Transactions tab

### DIFF
--- a/SimpleGUIWallet/SimpleGUIWallet.py
+++ b/SimpleGUIWallet/SimpleGUIWallet.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     gui = Tk()
     gui.configure(background=bkgnd)
     gui.title("Super-Simple BitShares Wallet for Ledger Nano")
-    gui.geometry("800x560")
+    gui.geometry("800x580")
     gui.minsize(640,480)
     gui_style = ttk.Style()
     gui_style.theme_use('clam')

--- a/SimpleGUIWallet/wallet_actions.py
+++ b/SimpleGUIWallet/wallet_actions.py
@@ -146,7 +146,7 @@ def getSignatureFromNano(serial_tx_bytes, bip32_path):
     except:
         Logger.Write("Ledger Nano not found! Is it plugged in and unlocked?")
         raise
-    Logger.Write("Created transaction.  Please review and confirm on Ledger Nano S...")
+    Logger.Write("Please review and confirm transaction on Ledger Nano S...")
     offset = 0
     first = True
     signSize = len(serial_tx_bytes)
@@ -172,7 +172,7 @@ def getSignatureFromNano(serial_tx_bytes, bip32_path):
             if e.sw == 0x6e00:
                 Logger.Write("BitShares App not running on Nano.  Please check.")
             else:
-                Logger.Write("Tx Not Broadcast.  User declined - transaction not signed.")
+                Logger.Write("User declined - transaction not signed.")
             raise
         except:
             dongle.close()


### PR DESCRIPTION
Adds a tab to SimpleGUIWallet for working with "raw" transactions (JSON representations of BitShares transactions).  Allows to explicitly step through process of 1. serializing a transaction, 2. sending serialized bytes over APDU to the Nano to get a signature, and 3. broadcasting signed Tx on network.

Because the APDU bytes can be edited before sending to Nano for signing, allows to test resiliency of the on-device Nano app against corrupted or malicious APDU streams. 